### PR TITLE
fix: Remove misplaced curly brace, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ reads wsl_params.yml
 - check Forwardings rules (see ProxyV4 in wsl_params.yml)
 
 ### What do you need to ro create wsl_watchdog sheduled task : ?
-Just call  task.ps1. This script read thle yaml file wsl_params.yml, create wsl_watchdog task with 2 triggers :
+Install [Powershell-Yaml](https://github.com/cloudbase/powershell-yaml)
+
+* In PowerShell as Administrator
+
+    `Install-Module powershell-yaml`
+
+Edit wsl_params.yml for the WSL distro to use and the location of WSL-Watchdog scripts. `wsl --list` shows installed distros.
+
+Call wsl_create_task.ps1. This script read thle yaml file wsl_params.yml, create wsl_watchdog task with 2 triggers :
 - atstartup : to start wsl_watchdog.ps1 script
 - daily : start wsl_watchdog.ps1 script evry 5mn (see TaskDuration in wsl_params.yml)

--- a/wsl_watchdog.ps1
+++ b/wsl_watchdog.ps1
@@ -47,7 +47,6 @@ function LoadParams{
     $script:v4tov4IP        = [regex]::matches($(Invoke-Expression $ShowProxyV4ToV4), "(172\.\d{1,3}\.\d{1,3}\.\d{1,3})").value 
   }
  
- }
 function CheckProcess {
   $script:Restarted=$false
 


### PR DESCRIPTION
This repo was a huge help to get me sorted out, and having ssh access to my windows desktop without a login is like a dream come true. I found the task failing due to a misplaced curly brace, and thought it would help to add some details to the readme after setting up on a freshly installed Windows 10 system.

Thanks for making this available.